### PR TITLE
use current sdk 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "fabric-client": "^1.3.0",
-    "fabric-network": "^1.3.0-snapshot.43"
+    "fabric-client": "^1.4.0",
+    "fabric-network": "^1.4.0"
   }
 }


### PR DESCRIPTION
I was having grpc errors and service discovery failures when I modified your code to communicate with an IBP 2.0 SaaS offering.  I talked to Simon and he said it was due to running the 1.3.x.  